### PR TITLE
Add multilingual switcher and fix i18n

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -51,7 +51,7 @@ export default async function RootLayout({
 
   // Providing all messages to the client
   // side is the easiest way to get started
-  const messages = await getMessages(locale);
+  const messages = await getMessages({ locale });
 
   return (
     <html lang={locale} dir={locale === 'he' ? 'rtl' : 'ltr'}>
@@ -65,5 +65,4 @@ export default async function RootLayout({
         </NextIntlClientProvider>
       </body>
     </html>
-  );
-}
+  );}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,21 +2,14 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { useParams } from 'next/navigation';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
 import { 
-  Zap, 
-  Brain, 
-  Video, 
-  Image, 
-  Music, 
-  BarChart3, 
-  Calendar, 
-  Settings,
-  Play,
-  Pause,
-  ArrowRight,
+  Zap,
+  Brain,
+  Video,
+  BarChart3,
+  Calendar,
   Check,
-  Star,
   Users,
   TrendingUp,
   Globe,
@@ -25,7 +18,6 @@ import {
   Youtube,
   Linkedin,
   Twitter,
-  Languages
 } from 'lucide-react';
 
 const platforms = [
@@ -59,60 +51,6 @@ const features = [
   }
 ];
 
-// Language selector component
-function LanguageSelector() {
-  const params = useParams();
-  const currentLocale = params.locale as string;
-  
-  const languages = [
-    { code: 'en', name: 'English', flag: '🇺🇸' },
-    { code: 'fr', name: 'Français', flag: '🇫🇷' },
-    { code: 'es', name: 'Español', flag: '🇪🇸' },
-    { code: 'he', name: 'עברית', flag: '🇮🇱' }
-  ];
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleLanguageChange = (locale: string) => {
-    const currentPath = window.location.pathname;
-    const newPath = currentPath.replace(`/${currentLocale}`, `/${locale}`);
-    window.location.href = newPath;
-  };
-
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-colors"
-      >
-        <Languages className="w-4 h-4" />
-        <span className="text-sm">
-          {languages.find(lang => lang.code === currentLocale)?.flag}
-        </span>
-      </button>
-      
-      {isOpen && (
-        <div className="absolute top-full mt-2 right-0 bg-[#0d0d2b] border border-white/10 rounded-lg shadow-xl z-50 min-w-[150px]">
-          {languages.map((lang) => (
-            <button
-              key={lang.code}
-              onClick={() => {
-                handleLanguageChange(lang.code);
-                setIsOpen(false);
-              }}
-              className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-white/10 transition-colors first:rounded-t-lg last:rounded-b-lg ${
-                currentLocale === lang.code ? 'bg-white/5' : ''
-              }`}
-            >
-              <span className="text-lg">{lang.flag}</span>
-              <span className="text-sm">{lang.name}</span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
 
 export default function Home() {
   const t = useTranslations();
@@ -172,7 +110,7 @@ export default function Home() {
               <a href="#analytics" className="text-gray-300 hover:text-white transition-colors">
                 {t('navigation.analytics')}
               </a>
-              <LanguageSelector />
+              <LanguageSwitcher />
               <button className="btn-g">{t('navigation.getStarted')}</button>
             </div>
           </div>

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import {useParams, usePathname} from 'next/navigation';
+import { Link } from '@/navigation';
+import { Languages } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from '@/components/ui/dropdown-menu';
+
+const languages = [
+  { code: 'en', name: 'English', flag: '🇺🇸' },
+  { code: 'fr', name: 'Français', flag: '🇫🇷' },
+  { code: 'es', name: 'Español', flag: '🇪🇸' },
+  { code: 'he', name: 'עברית', flag: '🇮🇱' }
+];
+
+export default function LanguageSwitcher() {
+  const params = useParams();
+  const currentLocale = params.locale as string;
+  const pathname = usePathname();
+  const basePath = pathname.replace(/^\/[a-z]{2}/, '');
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-colors">
+        <Languages className="w-4 h-4" />
+        <span className="text-sm">
+          {languages.find((l) => l.code === currentLocale)?.flag}
+        </span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {languages.map((lang) => (
+          <DropdownMenuItem asChild key={lang.code} className={currentLocale === lang.code ? 'bg-white/5' : ''}>
+            <Link href={`/${lang.code}${basePath}`}
+              className="flex items-center gap-2 w-full">
+              <span className="text-lg">{lang.flag}</span>
+              <span className="text-sm">{lang.name}</span>
+            </Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,5 +1,8 @@
 import { getRequestConfig } from 'next-intl/server';
-
-export default getRequestConfig(async ({ locale }) => ({
-  messages: (await import(`./messages/${locale}.json`)).default
-}));
+export default getRequestConfig(async ({ locale }) => {
+  const currentLocale = locale ?? 'en';
+  return {
+    messages: (await import(`./messages/${currentLocale}.json`)).default,
+    locale: currentLocale
+  };
+});

--- a/navigation.ts
+++ b/navigation.ts
@@ -1,0 +1,6 @@
+import {createNavigation} from 'next-intl/navigation';
+
+const locales = ['en', 'fr', 'es', 'he'] as const;
+
+export const {Link, usePathname, useRouter, redirect, permanentRedirect} =
+  createNavigation({locales, localePrefix: 'always'});


### PR DESCRIPTION
## Summary
- fix `getMessages` call
- add a `LanguageSwitcher` component with flag icons
- centralize navigation helpers in `navigation.ts`
- ensure `i18n` returns a locale string
- use the new switcher in the home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ebe8c2b388323b9f95a85ab1a7ec1